### PR TITLE
Multilang fixes

### DIFF
--- a/grading/hdl/grading/graders.py
+++ b/grading/hdl/grading/graders.py
@@ -103,7 +103,7 @@ class HDLGrader(BaseGrader):
 
             result, debug_info['files_feedback'][testbench_file_name], feedback_info = self._construct_feedback(results)
             test_cases = (testbench_file_name, expected_output_name)
-            feedback_str = self.diff_tool.to_html_block(0, result, test_cases, debug_info)
+            feedback_str = self.diff_tool.hdl_to_html_block(0, result, test_cases, debug_info)
 
         feedback_info['global']['feedback'] = feedback_str
         set_feedback(feedback_info)
@@ -148,55 +148,8 @@ def handle_problem_action(problem_id, testbench, output, options=None):
 
 
 class DiffWaveDrom(Diff):
-    def to_html_block(self, test_id, result, test_case, debug_info):
-        """
-        This method creates a html block (rst embedding html) for a single test case.
-        Args:
-            - test_id (int):
-            - result: Represents the results for the feedback (check 'results.py')
-            - test_case (tuple): A pair of names. The input filename and the expected output filename
-            - debug_info (dict): Debugging information about the execution of the source code.
-        Returns:
-            An string representing the html block to be presented in the feedback about
-            a single test case.
-        """
-        input_filename = test_case[0]
-        if input_filename in self.output_diff_for:
-            diff_result = (
-                debug_info.get("files_feedback", {}).get(input_filename, {}).get("diff", None)
-            )
-
-            diff_available = diff_result is not None
-            diff_html = ""
-
-            if diff_available:
-                input_text_full, input_text = self.read_input_example(test_case)
-                template_info = {
-                    "test_id": test_id + 1,
-                    "result_name": result.name,
-                    "panel_id": "collapseDiff" + str(test_id),
-                    "block_id": "diffBlock" + str(test_id),
-                    "diff_result": diff_result.replace("\n", "\\n"),
-                    "input_text": input_text,
-                    "input_text_full": input_text_full,
-                    "title_input": test_case[0]
-                }
-
-                if self.show_input or input_text_full == "":
-                    diff_html = "".join(self.testcase_template).format(**template_info)
-                else:
-                    diff_html = "".join([self.testcase_template[0], self.testcase_template[2]]).format(**template_info)
-            else:
-                diff_html = """<ul><li><strong>Test {0}: {1} </strong></li></ul>""".format(
-                    test_id + 1, result.name)
-            # The function called is changed to updateWaveDromBlock where besides of the initial diff a timing diagram is shown
-            diff_html = diff_html.replace("updateDiffBlock", "updateWaveDromBlock")
-            # Embedding the html containing the diff into rst code.
-            htmlblock = html2rst(diff_html)
-        else:
-            htmlblock = '- **Test %d: %s**' % (test_id + 1, result.name)
-
-
-        return htmlblock
-
-
+    def hdl_to_html_block(self, test_id, result, test_case, debug_info):
+        html_block = self.to_html_block(test_id, result, test_case, debug_info)
+        if html_block.find("updateDiffBlock") != -1:
+            html_block = html_block.replace("updateDiffBlock", "updateWaveDromBlock")
+        return html_block

--- a/grading/multilang/grading/graders.py
+++ b/grading/multilang/grading/graders.py
@@ -39,12 +39,11 @@ class SimpleGrader(BaseGrader):
         options['show_input'] = True
         self.diff_tool = Diff(options)
         self.output_diff_for = set(options.get("output_diff_for", []))
-        self.diff_max_lines = options.get("diff_max_lines", 100)
         self.check_output = options.get('check_output', gutils.check_output)
-        self.time_limit = options.get('time_limit', 4)
+        self.time_limit = options.get('time_limit', 2)
         self.hard_time_limit = options.get('hard_time_limit', self.time_limit)
-        self.output_limit = options.get('output_limit', 4)
-        self.memory_limit = options.get('memory_limit', 100)
+        self.output_limit = options.get('output_limit', 2)
+        self.memory_limit = options.get('memory_limit', 50)
 
     def create_project(self):
         """
@@ -200,7 +199,7 @@ class SimpleGrader(BaseGrader):
                 if self.generate_diff and result == GraderResult.WRONG_ANSWER and input_filename in self.output_diff_for:
                     diff = html.escape(self.diff_tool.compute(stdout, expected_output))
 
-                # As output might be very long, store only a max of 50KBs characters.
+                # As output might be very long, store string of max 50 KBs.
                 _stdout_max_length = (2 ** 10) * 50
                 stdout = gutils.reduce_text(stdout, _stdout_max_length)
                 debug_info.update({

--- a/grading/multilang/grading/graders.py
+++ b/grading/multilang/grading/graders.py
@@ -177,6 +177,7 @@ class SimpleGrader(BaseGrader):
             memory = self.memory_limit
             return_code, stdout, stderr = project.run(input_file,
                                                       **{"time": time, "memory": memory, "hard-time": hard_time})
+            stderr = self._remove_sockets_exception(stderr)
             expected_output = expected_output_file.read()
             # In case the stdout takes more memory than the output limit. It sets the stdout to free up memory
             # and avoid memory leaks.
@@ -188,10 +189,10 @@ class SimpleGrader(BaseGrader):
             elif return_code == 0:
                 output_matches = self.check_output(stdout, expected_output)
                 result = GraderResult.ACCEPTED if output_matches else GraderResult.WRONG_ANSWER
-            elif not self.treat_non_zero_as_runtime_error:
-                result = GraderResult.WRONG_ANSWER
-            else:
+            elif self.treat_non_zero_as_runtime_error:
                 result = parse_non_zero_return_code(return_code)
+            else:
+                result = GraderResult.WRONG_ANSWER
 
             debug_info = {}
             if result != GraderResult.ACCEPTED:

--- a/grading/multilang/grading/graders.py
+++ b/grading/multilang/grading/graders.py
@@ -10,8 +10,10 @@ import html
 import tempfile
 import projects
 import re
+from sys import getsizeof
+import gc
 
-from results import GraderResult, parse_non_zero_return_code
+from results import GraderResult, parse_non_zero_return_code, SandboxCodes
 from zipfile import ZipFile
 from base_grader import BaseGrader
 from feedback_tools import Diff, set_feedback
@@ -36,7 +38,13 @@ class SimpleGrader(BaseGrader):
         self.treat_non_zero_as_runtime_error = options.get("treat_non_zero_as_runtime_error", True)
         options['show_input'] = True
         self.diff_tool = Diff(options)
+        self.output_diff_for = set(options.get("output_diff_for", []))
+        self.diff_max_lines = options.get("diff_max_lines", 100)
         self.check_output = options.get('check_output', gutils.check_output)
+        self.time_limit = options.get('time_limit', 4)
+        self.hard_time_limit = options.get('hard_time_limit', self.time_limit)
+        self.output_limit = options.get('output_limit', 4)
+        self.memory_limit = options.get('memory_limit', 100)
 
     def create_project(self):
         """
@@ -48,7 +56,6 @@ class SimpleGrader(BaseGrader):
         """
         request = self.submission_request
         project_factory = projects.get_factory_from_name(request.language_name)
-
         if request.problem_type == 'code_multiple_languages':
             project = project_factory.create_from_code(request.code)
             return project
@@ -164,31 +171,45 @@ class SimpleGrader(BaseGrader):
             of zero return code. Check 'results.py')
             And the debug information in the execution.
         """
-
         with open(input_filename, 'r') as input_file, open(expected_output_filename, 'r') as expected_output_file:
-            return_code, stdout, stderr = project.run(input_file)
+            time = self.time_limit
+            hard_time = self.time_limit
+            memory = self.memory_limit
+            return_code, stdout, stderr = project.run(input_file,
+                                                      **{"time": time, "memory": memory, "hard-time": hard_time})
             expected_output = expected_output_file.read()
-
-            if return_code == 0 or (not self.treat_non_zero_as_runtime_error and
-                                    parse_non_zero_return_code(return_code) == GraderResult.RUNTIME_ERROR):
+            # In case the stdout takes more memory than the output limit. It sets the stdout to free up memory
+            # and avoid memory leaks.
+            if getsizeof(stdout) > self.output_limit:
+                stdout = ""
+                # Call the garbage collector to reduce memory usage
+                gc.collect()
+                result = GraderResult.OUTPUT_LIMIT_EXCEEDED
+            elif return_code == 0:
                 output_matches = self.check_output(stdout, expected_output)
                 result = GraderResult.ACCEPTED if output_matches else GraderResult.WRONG_ANSWER
+            elif not self.treat_non_zero_as_runtime_error:
+                result = GraderResult.WRONG_ANSWER
             else:
                 result = parse_non_zero_return_code(return_code)
 
             debug_info = {}
             if result != GraderResult.ACCEPTED:
                 diff = None
-                if self.generate_diff:
-                    diff = self.diff_tool.compute(stdout, expected_output)
+                if self.generate_diff and result == GraderResult.WRONG_ANSWER and input_filename in self.output_diff_for:
+                    diff = html.escape(self.diff_tool.compute(stdout, expected_output))
 
+                # As output might be very long, store only a max of 50KBs characters.
+                _stdout_max_length = (2 ** 10) * 50
+                stdout = gutils.reduce_text(stdout, _stdout_max_length)
                 debug_info.update({
                     "input_file": input_filename,
                     "stdout": html.escape(stdout),
                     "stderr": html.escape(stderr),
                     "return_code": return_code,
-                    "diff": None if diff is None else html.escape(diff),
+                    "diff": diff,
                 })
+                gc.collect()
 
             return result, debug_info
 
@@ -242,9 +263,13 @@ class SimpleGrader(BaseGrader):
         with open(custom_input_filename, 'r') as input_file:
             try:
                 project.build()
-                return_code, stdout, stderr = project.run(input_file)
+                time = self.time_limit
+                hard_time = self.time_limit
+                memory = self.memory_limit
+                return_code, stdout, stderr = project.run(input_file,
+                                                          **{"time": time, "memory": memory, "hard-time": hard_time})
                 return return_code, stdout, stderr
-            except:
+            except projects.BuildError as e:
                 raise
 
     def _generate_custom_input_feedback_info(self, return_code, stdout, stderr):
@@ -262,15 +287,27 @@ class SimpleGrader(BaseGrader):
         """
 
         feedback_info = {'global': {}, 'custom': {}}
-
-        if return_code == 0:
+        # In case the stdout takes more memory than the output limit. It sets the stdout to free up memory
+        # and avoid memory leaks.
+        if getsizeof(stdout) > self.output_limit:
+            stdout = ""
+            # Call the garbage collector to reduce memory usage
+            gc.collect()
+            feedback_info['global']['return'] = GraderResult.OUTPUT_LIMIT_EXCEEDED
+            feedback_info['global']['feedback'] = gutils.html_to_rst(
+                "Your code exceeded the output limit: <strong>%s</strong>" % feedback_info['global']['return'].name)
+        elif return_code == 0:
             feedback_info['global']['return'] = GraderResult.ACCEPTED
-            feedback_info['global']['feedback'] = gutils.html_to_rst("Your code finished successfully. Check your output below\n")
+            feedback_info['global']['feedback'] = gutils.html_to_rst(
+                "Your code finished successfully. Check your output below\n.")
         else:
             feedback_info['global']['return'] = parse_non_zero_return_code(return_code)
             feedback_info['global']['feedback'] = gutils.html_to_rst(
                 "Your code did not run successfully: <strong>%s</strong>" % (feedback_info['global']['return'].name,))
-        feedback_info['custom']['stdout'] = stdout
+        # Output length will be 80 KBs at most.
+        _stdout_max_length = (2 ** 10) * 80
+        feedback_info['custom']['stdout'] = gutils.reduce_text(stdout,
+                                                               _stdout_max_length) + "\nLong output, it was reduced."
         feedback_info['custom']['stderr'] = self._remove_sockets_exception(stderr)
 
         feedback_info['global']['result'] = "success" if feedback_info['global'][

--- a/grading/uncode/grading/graders_utils.py
+++ b/grading/uncode/grading/graders_utils.py
@@ -2,6 +2,7 @@
 This module contains the util functions for the grader and feedback_tools modules.
 """
 import rst
+from sys import getsizeof
 
 
 def html_to_rst(html):
@@ -24,3 +25,17 @@ def check_output(actual_output, expected_output):
     """
 
     return actual_output == expected_output
+
+
+def reduce_text(text, max_size):
+    if getsizeof(text) <= max_size:
+        return text
+    else:
+        split_text = text.split('\n')
+        new_text = []
+        for s in split_text:
+            new_text.append(s)
+            if getsizeof(new_text) >= max_size:
+                break
+
+        return '\n'.join(new_text)

--- a/grading/uncode/grading/results.py
+++ b/grading/uncode/grading/results.py
@@ -1,5 +1,6 @@
 from enum import IntEnum
 
+
 class GraderResult(IntEnum):
     """
     Represents a result of the grader. Results are ordered by precedence (lower values override
@@ -12,11 +13,14 @@ class GraderResult(IntEnum):
     WRONG_ANSWER = 50
     INTERNAL_ERROR = 60
     ACCEPTED = 70
+    OUTPUT_LIMIT_EXCEEDED = 80
+
 
 class SandboxCodes(IntEnum):
     MEMORY_LIMIT = 252
     TIME_LIMIT = 253
     INTERNAL_ERROR = 254
+
 
 def parse_non_zero_return_code(return_code):
     assert return_code != 0


### PR DESCRIPTION
Here there are several fixes:
- Run every test case with a given time and memory limit.
- Limit the output to manage long outputs. Here a new result is created **OUTPUT_LIMIT_EXCEEDED**
- Limit the length of strings to calculate the diff as this was causing a big memory usage and making the container to kill.
- Stop showing diff for all kind of feedbacks, now it shows only when Wrong Answer
- Show to students the runtime error.
- As the `to_html_block` function changed, HDL y also changed to generate the feedback correctly.
- Fix correctly when stdin or stdout has some special character making the diff js function to fail.

In general, this helps to fix [INGInious#157](https://github.com/JuezUN/INGInious/issues/157)