### PR TITLE
Set a fixed version for pandas and numpy as latest have some known bugs

### DIFF
--- a/grading/notebook/Dockerfile
+++ b/grading/notebook/Dockerfile
@@ -5,7 +5,7 @@ LABEL   org.inginious.grading.name="Notebook"
 
 # Add python modules and OK grading module
 RUN     pip3 install --upgrade pip
-RUN     pip3 install jupyter pandas numpy matplotlib scipy scikit-learn seaborn datascience \
+RUN     pip3 install jupyter pandas==1.0.5 numpy==1.18.5 matplotlib scipy scikit-learn seaborn datascience \
         plotly cufflinks bokeh tabulate nltk==3.4.5 tensorflow Keras statsmodels
 RUN     pip3 install --no-cache-dir --upgrade okpy
 


### PR DESCRIPTION
# Description

Set pandas and numpy versions as `1.0.5` and `1.18.5` respectively. This to have a similar environment as in Google Colab. Also, for instance pandas `1.1.1` version has some bugs that cause grader to wrongly grade submissions. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Container built and submission tested.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
