### PR TITLE
Preprocess submitted notebook to remove test cells

### DIFF
--- a/grading/notebook/grading/notebook_project.py
+++ b/grading/notebook/grading/notebook_project.py
@@ -68,7 +68,9 @@ def _copy_files_to_student_dir(notebook_filepath):
 
 def _convert_nb_to_python_script(notebook_path, filename):
     # Extract the python code within the same folder where the code is located.
-    command = ["jupyter", "nbconvert", "--to", "python", notebook_path, "--TemplateExporter.exclude_markdown=True"]
+    test_cells_regex = r"# TEST CELL\s*"  # Matches cells with the comment '# TEST CELL' followed 0 o more whitespaces.
+    command = ["jupyter", "nbconvert", "--to", "python", notebook_path, "--TemplateExporter.exclude_markdown=True",
+               "--RegexRemovePreprocessor.patterns=['{}']".format(test_cells_regex)]
     return_code, stdout, stderr = _run_command(command)
 
     python_script_path = "{}.py".format(filename)


### PR DESCRIPTION
# Description

The presence of test cells in the submitted notebook might slow down the time taken to run the submission. To manage that, code cells that contain the python comment line '# TEST CELL' in the beginning, are not parsed and removed from the submission as in the next image.

![image](https://user-images.githubusercontent.com/22863695/94488984-498cd800-01a9-11eb-87d3-076bdce4d654.png)


## Type of change

-  New feature

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- Locally compiling the container.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
