### PR TITLE
[Notebook container] Change the test cell regex and add a ignore flag

### DIFF
--- a/grading/notebook/grading/notebook_project.py
+++ b/grading/notebook/grading/notebook_project.py
@@ -67,10 +67,15 @@ def _copy_files_to_student_dir(notebook_filepath):
 
 
 def _convert_nb_to_python_script(notebook_path, filename):
+    remove_cells_regex = [
+        "'%s'" % r"\s*#\s*TEST_CELL\s*",
+        "'%s'" % r"\s*#\s*IGNORE_CELL\s*",
+    ]  # Matches cells with the comment '#TEST_CELL' and '#IGNORE_CELL' which also accepts several whitespaces.
+    remove_cells = ','.join(remove_cells_regex)
+
     # Extract the python code within the same folder where the code is located.
-    test_cells_regex = r"# TEST CELL\s*"  # Matches cells with the comment '# TEST CELL' followed 0 o more whitespaces.
     command = ["jupyter", "nbconvert", "--to", "python", notebook_path, "--TemplateExporter.exclude_markdown=True",
-               "--RegexRemovePreprocessor.patterns=['{}']".format(test_cells_regex)]
+               "--RegexRemovePreprocessor.patterns=[{}]".format(remove_cells)]
     return_code, stdout, stderr = _run_command(command)
 
     python_script_path = "{}.py".format(filename)


### PR DESCRIPTION
# Description

Test cell regex accepts now whitespaces before the comment and between the # and the text. To set a cell as test cell use at the beginning of the cell: `#TEST_CELL`. Other kind of cells that you want to ignore use: `#IGNORE_CELL`.
