### PR TITLE
Fix custom test for notebooks

### DIFF
--- a/grading/notebook/grading/utils.py
+++ b/grading/notebook/grading/utils.py
@@ -44,6 +44,9 @@ def _generate_feedback_info(grader_results, debug_info, weights, tests):
         filename and amount of test_cases.
     """
 
+    tests = [test for test in tests if test]
+    grader_results = [result for result in grader_results if result]
+
     if weights is None:
         weights = [1] * len(tests)
     results = [grader_result["result"] for grader_result in grader_results]


### PR DESCRIPTION
# Description

Small fix when a test is selected to be run in a notebook, as the debug info was shown and the actual order of tests was ignored. Causing that tests show debug info when the shouldn't.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
