### PR TITLE
Fix feedback for multilang and notebook

### DIFF
--- a/grading/multilang/grading/graders.py
+++ b/grading/multilang/grading/graders.py
@@ -241,7 +241,7 @@ class SimpleGrader(BaseGrader):
         feedback_info['custom']['additional_info'] = json.dumps(debug_info)
         feedback_info['custom']['summary_result'] = summary_result.name
         feedback_info['global']['result'] = "success" if passing == len(test_cases) else "failed"
-        feedback_info['grade'] = score * 100.0 / total_sum
+        feedback_info['grade'] = (score * 100.0 / total_sum) if total_sum else 100
 
         return feedback_info
 

--- a/grading/multilang/grading/graders.py
+++ b/grading/multilang/grading/graders.py
@@ -241,7 +241,7 @@ class SimpleGrader(BaseGrader):
         feedback_info['custom']['additional_info'] = json.dumps(debug_info)
         feedback_info['custom']['summary_result'] = summary_result.name
         feedback_info['global']['result'] = "success" if passing == len(test_cases) else "failed"
-        feedback_info['grade'] = (score * 100.0 / total_sum) if total_sum else 100
+        feedback_info['grade'] = (score * 100.0 / total_sum) if total_sum > 0 else 100.0
 
         return feedback_info
 

--- a/grading/notebook/grading/notebook_project.py
+++ b/grading/notebook/grading/notebook_project.py
@@ -67,22 +67,24 @@ def _copy_files_to_student_dir(notebook_filepath):
 
 
 def _convert_nb_to_python_script(notebook_path, filename):
-    remove_cells_regex = [
-        "'%s'" % r"\s*#\s*TEST_CELL\s*",
-        "'%s'" % r"\s*#\s*IGNORE_CELL\s*",
-    ]  # Matches cells with the comment '#TEST_CELL' and '#IGNORE_CELL' which also accepts several whitespaces.
-    remove_cells = ','.join(remove_cells_regex)
+    try:
+        remove_cells_regex = [
+            "'%s'" % r"\s*#\s*TEST_CELL\s*",
+            "'%s'" % r"\s*#\s*IGNORE_CELL\s*",
+        ]  # Matches cells with the comment '#TEST_CELL' and '#IGNORE_CELL' which also accepts several whitespaces.
+        remove_cells = ','.join(remove_cells_regex)
 
-    # Extract the python code within the same folder where the code is located.
-    command = ["jupyter", "nbconvert", "--to", "python", notebook_path, "--TemplateExporter.exclude_markdown=True",
-               "--RegexRemovePreprocessor.patterns=[{}]".format(remove_cells)]
-    return_code, stdout, stderr = _run_command(command)
+        # Extract the python code within the same folder where the code is located.
+        command = ["jupyter", "nbconvert", "--to", "python", notebook_path, "--TemplateExporter.exclude_markdown=True",
+                   "--RegexRemovePreprocessor.patterns=[{}]".format(remove_cells)]
+        _run_command(command)
 
-    python_script_path = "{}.py".format(filename)
-    processed_code = _preprocess_code(python_script_path)
-    with open(python_script_path, "w") as python_script:
-        python_script.write(processed_code)
-    return return_code, stdout, stderr
+        python_script_path = "{}.py".format(filename)
+        processed_code = _preprocess_code(python_script_path)
+        with open(python_script_path, "w") as python_script:
+            python_script.write(processed_code)
+    except Exception as e:
+        raise BuildError("Unexpected error while parsing the notebook. Check that your notebook runs correctly and try again.")
 
 
 def _preprocess_code(python_script_path):

--- a/grading/notebook/grading/utils.py
+++ b/grading/notebook/grading/utils.py
@@ -71,7 +71,7 @@ def _generate_feedback_info(grader_results, debug_info, weights, tests):
     feedback_info['custom']['summary_result'] = summary_result.name
     feedback_info['custom']['internal_error'] = "\n".join(internal_errors)
     feedback_info['global']['result'] = "success" if passing == len(tests) else "failed"
-    feedback_info['grade'] = score * 100.0 / total_sum
+    feedback_info['grade'] = score * 100.0 / total_sum if total_sum > 0 else 100.0
 
     return feedback_info
 

--- a/grading/uncode/grading/feedback_tools.py
+++ b/grading/uncode/grading/feedback_tools.py
@@ -79,13 +79,13 @@ class Diff:
         expected_output = reduce_text(expected_output, _max_length)
         expected_output_lines = expected_output.splitlines()
         # In case the expected output has an end of line at the end, add it to the split lines.
-        if expected_output[-1] == '\n':
+        if expected_output and expected_output[-1] == '\n':
             expected_output_lines.append("\n")
 
         actual_output = reduce_text(current_output, _max_length)
         actual_output_lines = actual_output.splitlines()
         # In case the actual output has an end of line at the end, add it to the split lines.
-        if actual_output[-1] == '\n':
+        if actual_output and actual_output[-1] == '\n':
             actual_output_lines.append("\n")
 
         diff_generator = difflib.unified_diff(expected_output_lines, actual_output_lines, n=self.diff_context_lines,


### PR DESCRIPTION
# Description

This fixes three different small bugs:
- In case the sum of weights of all test cases is zero for multilang or notebook, set 100.0. However this is very unlikely to happen.
- Show a better error message when nbconvert fails.
- Fix in multilang raising exception when the solution's stdout is empty.

## Type of change

-  Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Locally testing the several use cases where it fails.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
