### PR TITLE
Show hints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
     - PROJECT_SANDBOX_FOLDER=/task/student
 
 install:
+  - docker build -t unjudge/uncode-c-base ./grading/uncode
   - ./build-container.sh multilang
 
 script:

--- a/grading/hdl/grading/graders.py
+++ b/grading/hdl/grading/graders.py
@@ -108,7 +108,7 @@ class HDLGrader(BaseGrader):
 
             feedback_str = ''
             grade_penalty = self.submission_request.penalty
-            if feedback_info['global']['result'] is 'success' or (feedback_info['global']['result'] is 'failed' and feedback_info['grade'] and grade_penalty):
+            if (feedback_info['global']['result'] is 'success' or (feedback_info['global']['result'] is 'failed' and feedback_info['grade'])) and grade_penalty:
                 feedback_applied_penalty = feedback_penalty(grade_penalty)
                 feedback_str = feedback_applied_penalty
 

--- a/grading/hdl/grading/graders.py
+++ b/grading/hdl/grading/graders.py
@@ -123,8 +123,9 @@ class HDLGrader(BaseGrader):
         if return_code == 0:
             expected_output = stdout_golden
             correct = self.check_output(stdout, expected_output)
+            grade_penalty = self.submission_request.penalty;
             feedback_info['global']['result'] = "success" if correct else "failed"
-            feedback_info['grade'] = 100.0 if correct else 0.0
+            feedback_info['grade'] = (100.0 - grade_penalty) if correct else 0.0
             if correct:
                 result = GraderResult.ACCEPTED
 

--- a/grading/hdl/grading/graders.py
+++ b/grading/hdl/grading/graders.py
@@ -105,12 +105,14 @@ class HDLGrader(BaseGrader):
 
             result, debug_info['files_feedback'][testbench_file_name], feedback_info = self._construct_feedback(results)
             test_cases = (testbench_file_name, expected_output_name)
+
             feedback_str = ''
             grade_penalty = self.submission_request.penalty
-            if grade_penalty:
-                feedback_str += feedback_penalty(grade_penalty)
-            feedback_str += self.diff_tool.hdl_to_html_block(0, result, test_cases, debug_info)
+            if feedback_info['global']['result'] is 'success' or (feedback_info['global']['result'] is 'failed' and feedback_info['grade'] and grade_penalty):
+                feedback_applied_penalty = feedback_penalty(grade_penalty)
+                feedback_str = feedback_applied_penalty
 
+            feedback_str += self.diff_tool.hdl_to_html_block(0, result, test_cases, debug_info)
 
         feedback_info['global']['feedback'] = feedback_str
         set_feedback(feedback_info)

--- a/grading/multilang/grading/graders.py
+++ b/grading/multilang/grading/graders.py
@@ -15,7 +15,7 @@ import gc
 from results import GraderResult, parse_non_zero_return_code, SandboxCodes
 from zipfile import ZipFile
 from base_grader import BaseGrader
-from feedback_tools import Diff, set_feedback
+from feedback_tools import Diff, set_feedback, feedback_penalty
 import graders_utils as gutils
 from submission_requests import SubmissionRequest
 from .utils import remove_sockets_exception, cut_stderr
@@ -94,6 +94,8 @@ class SimpleGrader(BaseGrader):
         else:
             # Generate feedback string for tests
             feedback_list = []
+            feedback_list.append(feedback_penalty(grade_penalty))
+
             for i, result in enumerate(results):
                 test_case = test_cases[i]
                 feedback_list.append(self.diff_tool.to_html_block(i, result, test_case, debug_info))

--- a/grading/multilang/grading/graders.py
+++ b/grading/multilang/grading/graders.py
@@ -328,7 +328,7 @@ class SimpleGrader(BaseGrader):
 
         feedback_info['global']['result'] = "success" if feedback_info['global'][
                                                              'return'] == GraderResult.ACCEPTED else "failed"
-        feedback_info['grade'] = (100.0 - penalty) if feedback_info['global']['return'] == GraderResult.ACCEPTED else 0.0
+        feedback_info['grade'] = 100.0 if feedback_info['global']['return'] == GraderResult.ACCEPTED else 0.0
 
         return feedback_info
 

--- a/grading/multilang/grading/graders.py
+++ b/grading/multilang/grading/graders.py
@@ -95,15 +95,17 @@ class SimpleGrader(BaseGrader):
             # Generate feedback string for tests
             feedback_list = []
 
-            if grade_penalty:
-                feedback_list.append(feedback_penalty(grade_penalty))
-
             for i, result in enumerate(results):
                 test_case = test_cases[i]
                 feedback_list.append(self.diff_tool.to_html_block(i, result, test_case, debug_info))
             feedback_str = '\n\n'.join(feedback_list)
 
         feedback_info = self._generate_feedback_info(results, debug_info, weights, test_cases, grade_penalty)
+
+        if feedback_info['global']['result'] is 'success' or (feedback_info['global']['result'] is 'failed' and feedback_info['grade'] and grade_penalty):
+            feedback_applied_penalty = feedback_penalty(grade_penalty)
+            feedback_str = feedback_applied_penalty + feedback_str
+
         feedback_info['global']['feedback'] = feedback_str
 
         set_feedback(feedback_info)

--- a/grading/multilang/grading/graders.py
+++ b/grading/multilang/grading/graders.py
@@ -94,7 +94,9 @@ class SimpleGrader(BaseGrader):
         else:
             # Generate feedback string for tests
             feedback_list = []
-            feedback_list.append(feedback_penalty(grade_penalty))
+
+            if grade_penalty:
+                feedback_list.append(feedback_penalty(grade_penalty))
 
             for i, result in enumerate(results):
                 test_case = test_cases[i]
@@ -244,7 +246,9 @@ class SimpleGrader(BaseGrader):
         summary_result = gutils.compute_summary_result(results)
 
         final_grade = (score * 100.0 / total_sum) if total_sum > 0 else 100.0
-        final_grade = 0 if final_grade < grade_penalty else (final_grade - grade_penalty)
+
+        if grade_penalty:
+            final_grade = 0.0 if final_grade < grade_penalty else (final_grade - grade_penalty)
 
         feedback_info['custom']['additional_info'] = json.dumps(debug_info)
         feedback_info['custom']['summary_result'] = summary_result.name

--- a/grading/multilang/grading/graders.py
+++ b/grading/multilang/grading/graders.py
@@ -102,7 +102,7 @@ class SimpleGrader(BaseGrader):
 
         feedback_info = self._generate_feedback_info(results, debug_info, weights, test_cases, grade_penalty)
 
-        if feedback_info['global']['result'] is 'success' or (feedback_info['global']['result'] is 'failed' and feedback_info['grade'] and grade_penalty):
+        if (feedback_info['global']['result'] is 'success' or (feedback_info['global']['result'] is 'failed' and GraderResult.ACCEPTED in results)) and grade_penalty:
             feedback_applied_penalty = feedback_penalty(grade_penalty)
             feedback_str = feedback_applied_penalty + feedback_str
 

--- a/grading/multilang/tests/test_grading/test_grader.py
+++ b/grading/multilang/tests/test_grading/test_grader.py
@@ -78,10 +78,10 @@ class TestGrader(object):
         sub_req = MagicMock()
         # Create temporal file for test cases pair        
         grader = SimpleGrader(sub_req, {'compute_diff': False})
-        feedback_info = grader._generate_feedback_info([GraderResult.ACCEPTED], {}, None, [('dummy', 'dummy')])
+        feedback_info = grader._generate_feedback_info([GraderResult.ACCEPTED], {}, None, [('dummy', 'dummy')], 0.0)
         assert feedback_info['grade'] == 100.0
         assert feedback_info['global']['result'] == 'success'
-        feedback_info = grader._generate_feedback_info([GraderResult.WRONG_ANSWER], {}, None, [('dummy', 'dummy')])
+        feedback_info = grader._generate_feedback_info([GraderResult.WRONG_ANSWER], {}, None, [('dummy', 'dummy')], 0.0)
         assert feedback_info['grade'] == 0.0
         assert feedback_info['global']['result'] == 'failed'
 

--- a/grading/notebook/grading/graders.py
+++ b/grading/notebook/grading/graders.py
@@ -12,7 +12,7 @@ from collections import OrderedDict
 
 from results import GraderResult, parse_non_zero_return_code
 from base_grader import BaseGrader
-from feedback_tools import Diff, set_feedback
+from feedback_tools import Diff, set_feedback, feedback_penalty
 from submission_requests import SubmissionRequest
 
 from .notebook_project import get_notebook_factory
@@ -86,6 +86,10 @@ class NotebookGrader(BaseGrader):
             else:
                 # Generate feedback string for tests
                 feedbacklist = []
+
+                grade_penalty = self.submission_request.penalty
+                if(grade_penalty is not 0):
+                    feedbacklist.append(feedback_penalty(grade_penalty))
                 for i, test_result in enumerate(tests_results):
                     if not test_result:
                         continue
@@ -94,10 +98,10 @@ class NotebookGrader(BaseGrader):
                     test_custom_feedback = self.custom_feedback.get(i, "")
                     feedbacklist.append(
                         _result_to_html(i, test_result, weights[i], show_debug_info, test_custom_feedback))
-                grade_penalty = self.submission_request.penalty
-                feedback_str = '\n\n'.join(feedbacklist)
 
                 feedback_info = _generate_feedback_info(tests_results, debug_info, weights, tests, grade_penalty)
+
+                feedback_str = '\n\n'.join(feedbacklist)
                 feedback_info['global']['feedback'] = feedback_str
 
                 set_feedback(feedback_info)

--- a/grading/notebook/grading/graders.py
+++ b/grading/notebook/grading/graders.py
@@ -102,7 +102,7 @@ class NotebookGrader(BaseGrader):
 
                 feedback_str = '\n\n'.join(feedbacklist)
 
-                if feedback_info['global']['result'] is 'success' or (feedback_info['global']['result'] is 'failed' and feedback_info['grade'] and grade_penalty):
+                if (feedback_info['global']['result'] is 'success' or (feedback_info['global']['result'] is 'failed' and GraderResult.ACCEPTED in result_codes)) and grade_penalty:
                     feedback_applied_penalty = feedback_penalty(grade_penalty)
                     feedback_str = feedback_applied_penalty + feedback_str
 

--- a/grading/notebook/grading/graders.py
+++ b/grading/notebook/grading/graders.py
@@ -94,9 +94,10 @@ class NotebookGrader(BaseGrader):
                     test_custom_feedback = self.custom_feedback.get(i, "")
                     feedbacklist.append(
                         _result_to_html(i, test_result, weights[i], show_debug_info, test_custom_feedback))
+                grade_penalty = self.submission_request.penalty
                 feedback_str = '\n\n'.join(feedbacklist)
 
-                feedback_info = _generate_feedback_info(tests_results, debug_info, weights, tests)
+                feedback_info = _generate_feedback_info(tests_results, debug_info, weights, tests, grade_penalty)
                 feedback_info['global']['feedback'] = feedback_str
 
                 set_feedback(feedback_info)

--- a/grading/notebook/grading/graders.py
+++ b/grading/notebook/grading/graders.py
@@ -88,7 +88,7 @@ class NotebookGrader(BaseGrader):
                 feedbacklist = []
 
                 grade_penalty = self.submission_request.penalty
-                if(grade_penalty is not 0):
+                if grade_penalty:
                     feedbacklist.append(feedback_penalty(grade_penalty))
                 for i, test_result in enumerate(tests_results):
                     if not test_result:

--- a/grading/notebook/grading/graders.py
+++ b/grading/notebook/grading/graders.py
@@ -88,8 +88,7 @@ class NotebookGrader(BaseGrader):
                 feedbacklist = []
 
                 grade_penalty = self.submission_request.penalty
-                if grade_penalty:
-                    feedbacklist.append(feedback_penalty(grade_penalty))
+
                 for i, test_result in enumerate(tests_results):
                     if not test_result:
                         continue
@@ -102,6 +101,11 @@ class NotebookGrader(BaseGrader):
                 feedback_info = _generate_feedback_info(tests_results, debug_info, weights, tests, grade_penalty)
 
                 feedback_str = '\n\n'.join(feedbacklist)
+
+                if feedback_info['global']['result'] is 'success' or (feedback_info['global']['result'] is 'failed' and feedback_info['grade'] and grade_penalty):
+                    feedback_applied_penalty = feedback_penalty(grade_penalty)
+                    feedback_str = feedback_applied_penalty + feedback_str
+
                 feedback_info['global']['feedback'] = feedback_str
 
                 set_feedback(feedback_info)

--- a/grading/notebook/grading/utils.py
+++ b/grading/notebook/grading/utils.py
@@ -59,7 +59,9 @@ def _generate_feedback_info(grader_results, debug_info, weights, tests, grade_pe
     total_sum = sum(weights)
 
     final_grade = (score * 100.0 / total_sum) if total_sum > 0 else 100.0
-    final_grade = 0 if final_grade < grade_penalty else (final_grade - grade_penalty)
+
+    if grade_penalty:
+        final_grade = 0.0 if final_grade < grade_penalty else (final_grade - grade_penalty)
 
     summary_result = gutils.compute_summary_result(results)
 

--- a/grading/notebook/grading/utils.py
+++ b/grading/notebook/grading/utils.py
@@ -30,7 +30,7 @@ def _generate_feedback_info_internal_error(debug_info):
     return feedback_info
 
 
-def _generate_feedback_info(grader_results, debug_info, weights, tests):
+def _generate_feedback_info(grader_results, debug_info, weights, tests, grade_penalty):
     """
     This method generates a dictionary containing the information for the feedback
     setting function (check 'feedback_tools.py')
@@ -42,6 +42,7 @@ def _generate_feedback_info(grader_results, debug_info, weights, tests):
         - weights (list): List of integers containing the importance of the nth-test
         - tests (list of tuples): A list containing a tuples with three values. The test's name, test's
         filename and amount of test_cases.
+        - grade_penalty (float): Value to be applied in grade
     """
 
     tests = [test for test in tests if test]
@@ -57,6 +58,9 @@ def _generate_feedback_info(grader_results, debug_info, weights, tests):
     score = sum(grades)
     total_sum = sum(weights)
 
+    final_grade = (score * 100.0 / total_sum) if total_sum > 0 else 100.0
+    final_grade = 0 if final_grade < grade_penalty else (final_grade - grade_penalty)
+
     summary_result = gutils.compute_summary_result(results)
 
     internal_errors = []
@@ -71,7 +75,7 @@ def _generate_feedback_info(grader_results, debug_info, weights, tests):
     feedback_info['custom']['summary_result'] = summary_result.name
     feedback_info['custom']['internal_error'] = "\n".join(internal_errors)
     feedback_info['global']['result'] = "success" if passing == len(tests) else "failed"
-    feedback_info['grade'] = score * 100.0 / total_sum if total_sum > 0 else 100.0
+    feedback_info['grade'] = final_grade
 
     return feedback_info
 

--- a/grading/uncode/grading/feedback_tools.py
+++ b/grading/uncode/grading/feedback_tools.py
@@ -201,3 +201,17 @@ def set_feedback(results):
 
 def escape_text(text):
     return text.replace('\\', "\\\\").replace('`', "\\`").replace('\n', "\\n").replace("$", "\\$").replace('\t', "\\t")
+
+
+def feedback_penalty(grade_penalty):
+
+    """
+    This method sets a new message for the grade penalty of a submission
+
+    Args:
+        - grade_penalty (float): The total penalty to be applied for the final grade
+    """
+
+    penalty_msg = '<br><br><p>A penalty of <b>{penalty}%</b> was applied to this submission.</p>'
+    penalty_msg = penalty_msg.format(penalty=grade_penalty)
+    return html2rst(penalty_msg)

--- a/grading/uncode/grading/submission_requests.py
+++ b/grading/uncode/grading/submission_requests.py
@@ -44,10 +44,10 @@ class SubmissionRequest:
 
         code = input.get_input(problem_id)
 
-        try:
-            grade_penalty = input.get_input("penalty")[0]
-        except Exception:
-            grade_penalty = 0
+        grade_penalty = input.get_input("penalty")[0]
+
+        if grade_penalty is None:
+            grade_penalty = 0.0
 
         if language_name is None:
             language_name = input.get_input(problem_id + "/language")

--- a/grading/uncode/grading/submission_requests.py
+++ b/grading/uncode/grading/submission_requests.py
@@ -44,10 +44,7 @@ class SubmissionRequest:
 
         code = input.get_input(problem_id)
 
-        grade_penalty = input.get_input("penalty")[0]
-
-        if grade_penalty is None:
-            grade_penalty = 0.0
+        grade_penalty = input.get_input("penalty")
 
         if language_name is None:
             language_name = input.get_input(problem_id + "/language")

--- a/grading/uncode/grading/submission_requests.py
+++ b/grading/uncode/grading/submission_requests.py
@@ -22,6 +22,7 @@ class SubmissionRequest:
         language_name (str): Language name of the student's code 
         problem_type (str): Type of the problem submission (in the UNCode case: multiple files or single file)
         custom_input (str): String containing the student's input in case of testing
+        penalty (float): Penalty value to be applied in student's final score
     """
 
     def __init__(self, problem_id, language_name=None):
@@ -43,6 +44,11 @@ class SubmissionRequest:
 
         code = input.get_input(problem_id)
 
+        try:
+            grade_penalty = input.get_input("penalty")[0]
+        except Exception:
+            grade_penalty = 0
+
         if language_name is None:
             language_name = input.get_input(problem_id + "/language")
         problem_type = input.get_input(problem_id + "/type")
@@ -56,3 +62,4 @@ class SubmissionRequest:
         self.language_name = language_name
         self.problem_type = problem_type
         self.custom_input = custom_input
+        self.penalty = grade_penalty


### PR DESCRIPTION
# Description

These are the changes needed for the show hints' plugin to apply the penalty (by using hints) on the student's grade, when he made a submission. Also, add an additional feedback message for the applied penalty to help student to understand this total score.

Fixes # 266

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

It was tested locally by rebuilding the multilang, notebook and HDL grading containers, and sending sumbissions with penalty, no penalty (no hints unlocked), and 100% penalty, for each grading container. 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
