### PR TITLE
Update update-docker-images.yml

### DIFF
--- a/.github/workflows/update-docker-images.yml
+++ b/.github/workflows/update-docker-images.yml
@@ -19,6 +19,7 @@ jobs:
         tags: latest
         registry: docker.io
         directory: ./grading/uncode
+        dockerfile: ./grading/uncode/Dockerfile
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         
@@ -37,6 +38,7 @@ jobs:
         tags: latest
         registry: docker.io
         directory: ./grading/multilang
+        dockerfile: ./grading/multilang/Dockerfile
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         
@@ -55,6 +57,7 @@ jobs:
         tags: latest
         registry: docker.io
         directory: ./grading/data_science
+        dockerfile: ./grading/data_science/Dockerfile
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         
@@ -73,6 +76,7 @@ jobs:
         tags: latest
         registry: docker.io
         directory: ./grading/notebook
+        dockerfile: ./grading/notebook/Dockerfile
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         
@@ -91,6 +95,7 @@ jobs:
         tags: latest
         registry: docker.io
         directory: ./grading/hdl
+        dockerfile: ./grading/hdl/Dockerfile
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
   


### PR DESCRIPTION
# Description

I believe what the `Error: Command failed: docker build -f Dockerfile -t docker.io/unjudge/uncode-c-base:latest ./grading/uncode`  lets us see is that the -f flag is passed by default and its not inferred automatically from the source directory, thus, we must pass the explicit value of where the docker file is.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
