### PR TITLE
add dask_ml lib and update dask version on notebook container

### DIFF
--- a/grading/notebook/Dockerfile
+++ b/grading/notebook/Dockerfile
@@ -19,7 +19,7 @@ RUN     pip3.9 install requests==2.22.0
 RUN     pip3.9 install qiskit[visualization]==0.37.2
 
 #Installing Dask
-RUN     pip3.9 install dask[complete]==2022.9.2
+RUN     pip3.9 install dask[complete]==2022.10.2 dask_ml==2022.5.27
 # Download nltk data
 # RUN python3 -m nltk.downloader -d /usr/local/share/nltk_data all
 


### PR DESCRIPTION
# Description

This is a small PR with two minor changes on the Dockerfile of notebook container, first the dask version is change from 2022.9.2 to 2022.10.2 and the lib dask_ml was added on the version  2022.5.27

## Type of changes

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

This was tested on my own development environment doing submissions on a notebook task, with debug mode and checking that the libs were installed via pip list

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code