### PR TITLE
GitHub job ubuntu version 20.04

### DIFF
--- a/.github/workflows/i18n_action.yml
+++ b/.github/workflows/i18n_action.yml
@@ -5,9 +5,9 @@ on:
       - master
 jobs:
   check-i18n-files:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         with:
           python-version: '3.6'
           architecture: 'x64'


### PR DESCRIPTION
# Description

Now the latest version of Ubuntu on GitHub workers is 22.04, this have conflicts with the jobs because there is no version of python 3.6 for this OS. So instead of latest, we set the version on 20.04

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This PR and their jobs are the test.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code