### PR TITLE
Removing tensorflow 

### DIFF
--- a/grading/notebook/Dockerfile
+++ b/grading/notebook/Dockerfile
@@ -8,7 +8,7 @@ RUN     dnf install -y gcc gcc-c++
 # Add python modules and OK grading module
 RUN     pip3.9 install --upgrade pip
 RUN     pip3.9 install nbconvert==7.0.0 pandas==1.3.5 numpy==1.21.6 matplotlib==3.5.3 scipy==1.7.3 scikit-learn==1.0.2 \
-        seaborn==0.11.2 datascience==0.17.5 plotly==5.5.0 cufflinks==0.17.3 bokeh==2.3.3 tabulate==0.8.10 nltk==3.7 tensorflow==2.8.2 \
+        seaborn==0.11.2 datascience==0.17.5 plotly==5.5.0 cufflinks==0.17.3 bokeh==2.3.3 tabulate==0.8.10 nltk==3.7 \
         Keras==2.8.0 statsmodels==0.12.2 antlr4-python3-runtime geopandas==0.9.0 cassandra-driver==3.25.0 pymongo==4.2.0 
 
 # Last version of okpy is 1.18.1 on 2020


### PR DESCRIPTION
# Description

Removing tensorflow as: 
1. it is not used because the server have limited resources right now; 
2. it is in conflict with the instructions to dowload the Spanish spacy model: See Grader Server output when running the cointainer:

```
-bash-4.4$ python3 -m spacy download es_core_news_sm
The TensorFlow library was compiled to use SSE4.1 instructions, but these aren't available on your machine.
Aborted (core dumped)

```
## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
