### PR TITLE
Update libs on notebook container

### DIFF
--- a/grading/notebook/Dockerfile
+++ b/grading/notebook/Dockerfile
@@ -7,19 +7,19 @@ LABEL   org.inginious.grading.name="Notebook"
 RUN     dnf install -y gcc gcc-c++
 # Add python modules and OK grading module
 RUN     pip3.9 install --upgrade pip
-RUN     pip3.9 install nbconvert==7.0.0 pandas==1.3.5 numpy==1.21.6 matplotlib==3.5.3 scipy==1.7.3 scikit-learn==1.0.2 \
-        seaborn==0.11.2 datascience==0.17.5 plotly==5.5.0 cufflinks==0.17.3 bokeh==2.3.3 tabulate==0.8.10 nltk==3.7 \
-        Keras==2.8.0 statsmodels==0.12.2 antlr4-python3-runtime geopandas==0.9.0 cassandra-driver==3.25.0 pymongo==4.2.0 
+RUN     pip3.9 install nbconvert==7.0.0 pandas==1.5.3 numpy==1.22.4 matplotlib==3.7.1 scipy==1.10.1 scikit-learn==1.2.2 \
+        seaborn==0.12.2 datascience==0.17.6 plotly==5.13.1 cufflinks==0.17.3 bokeh==3.1.1 tabulate==0.9.0 nltk==3.8.1 tensorflow==2.12.0 \
+        Keras==2.12 statsmodels==0.13.5 antlr4-python3-runtime geopandas==0.13.2 cassandra-driver==3.28.0 pymongo==4.4.1 
 
-# Last version of okpy is 1.18.1 on 2020
+#Last version of okpy is 1.18.1 on 2020
 RUN     pip3.9 install --no-cache-dir --upgrade okpy==1.18.1
 # Necessary for okpy==1.18.1
 RUN     pip3.9 install requests==2.22.0
 # Installing qiskit
-RUN     pip3.9 install qiskit[visualization]==0.37.2
+RUN     pip3.9 install qiskit[visualization]==0.44.0
 
-# Installing Dask
-RUN     pip3.9 install dask[complete]==2022.10.2 dask_ml==2022.5.27
+#Installing Dask
+RUN     pip3.9 install dask[complete]==2023.7.1 dask_ml==2023.3.24
 # Installing unidecode
 RUN     pip3.9 install Unidecode==1.3.6
 # Installing gensim
@@ -32,6 +32,16 @@ RUN     python3 -m spacy download es_core_news_sm
 RUN     pip3.9 install pyarrow==10.0.1
 # Installing wordcloud
 RUN     pip3.9 install wordcloud==1.8.2.2
+
+#Uninstall attrs and jsonschema in order to install correct versions for okpy
+RUN     pip3.9 uninstall attrs jsonschema -y
+
+# Necessary for okpy==1.18.1
+RUN     pip3.9 install attrs==19.3.0 pipdeptree jsonschema==2.6.0
+
+#You can install In order to debug libs versions problems
+#RUN     pip3.9 install pipdeptree
+
 
 # Download nltk data
 # RUN python3 -m nltk.downloader -d /usr/local/share/nltk_data all


### PR DESCRIPTION
This PR update most of the libs installed on the notebook container and solve version conflicts:
The notebook Dockerfile was updated with the most recent versions on Colab:
These are:
Pandas Version : 1.5.3
Numpy Version : 1.22.4
Matplotlib Version : 3.7.1
Scipy Version : 1.10.1
Scikit Version : 1.2.2
Seaborn Version : 0.12.2
Datascience Version : 0.17.6
Plotly version : 5.13.1
Cufflinks version : 0.17.3
Bokeh Version  : 3.1.1
tabulate Version : 0.9.0
nltk Version : 3.8.1
tensorflow Version : 2.12.0
statsModels Version : 0.13.5

Other libs not present on Colab were updated to their last version suported on python 3.9:
Cassandra driver version: 3.28.0
Pymongo version: 4.4.1
quiskit version: 0.44
Keras version: 2.12
dask version: 2023.7.1
dask_ml version: 2023.3.24
geopandas version: 0.13.2