### PR TITLE
Incluiding -lm compilation flag for C11/C++11 projects

### DIFF
--- a/grading/uncode/grading/projects.py
+++ b/grading/uncode/grading/projects.py
@@ -448,9 +448,9 @@ _ALL_FACTORIES = {
                                 bootclasspath="/usr/lib/jvm/java-1.7.0-openjdk/jre/lib/rt.jar"),
     "java8": JavaProjectFactory(),
     "cpp": CppProjectFactory(["-O2"]),
-    "cpp11": CppProjectFactory(additional_flags=["-std=c++11", "-O2"]),
+    "cpp11": CppProjectFactory(additional_flags=["-std=c++11", "-O2", "-lm"]),
     "c": CProjectFactory(["-O2"]),
-    "c11": CProjectFactory(additional_flags=["-std=c11", "-O2"]),
+    "c11": CProjectFactory(additional_flags=["-std=c11", "-O2", "-lm"]),
     "verilog": VerilogProjectFactory(),
     "vhdl": VHDLProjectFactory()
 }


### PR DESCRIPTION
# Description

Incluiding -lm compilation flag for C11/C++11 projects. This passes info to the linker to work with the math.h library.
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

